### PR TITLE
Add filter for variants not supported by both strands

### DIFF
--- a/.github/workflows/juno_mapping_conda.yaml
+++ b/.github/workflows/juno_mapping_conda.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
+          generate-run-shell: false # see https://github.com/mamba-org/setup-micromamba/issues/130
           cache-downloads: true
           environment-file: envs/juno_mapping.yaml
       - name: Cache minikraken

--- a/.github/workflows/juno_mapping_singularity.yaml
+++ b/.github/workflows/juno_mapping_singularity.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
+          generate-run-shell: false # see https://github.com/mamba-org/setup-micromamba/issues/130
           cache-downloads: true
           environment-file: envs/juno_mapping.yaml
       - name: Cache minikraken

--- a/envs/juno_mapping.yaml
+++ b/envs/juno_mapping.yaml
@@ -8,9 +8,9 @@ dependencies:
   - git=2.40.*
   - mamba=1.3.*
   - pandas=1.5.*
-  - snakemake=7.18.*
+  - snakemake=7.32.*
   - pip=23.*
   - python=3.11.*
   - pyvcf
   - pip:
-    - "--editable=git+https://github.com/RIVM-bioinformatics/juno-library.git@v2.0.0#egg=juno_library"
+    - "--editable=git+https://github.com/RIVM-bioinformatics/juno-library.git@v2.1.2#egg=juno_library"

--- a/envs/juno_mapping.yaml
+++ b/envs/juno_mapping.yaml
@@ -8,7 +8,7 @@ dependencies:
   - git=2.40.*
   - mamba=1.3.*
   - pandas=1.5.*
-  - snakemake=7.32.*
+  - snakemake=7.32.0
   - pip=23.*
   - python=3.11.*
   - pyvcf

--- a/juno_mapping.py
+++ b/juno_mapping.py
@@ -7,15 +7,17 @@ Department: Infektieziekteonderzoek, Diagnostiek en Laboratorium
 Date: 25-05-2023   
 """
 
-from pathlib import Path
-import pathlib
-import yaml
 import argparse
+import pathlib
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
+
+import yaml
 from juno_library import Pipeline
-from typing import Optional, Callable, Union, Any
-from version import __package_name__, __version__, __description__
+
+from version import __description__, __package_name__, __version__
 
 
 def main() -> None:

--- a/juno_mapping.py
+++ b/juno_mapping.py
@@ -152,6 +152,13 @@ class JunoMapping(Pipeline):
             default=0.8,
             help="Minimum allele frequency to filter variants on.",
         )
+        self.add_argument(
+            "--min-reads-per-strand",
+            type=check_number_within_range(minimum=0, maximum=9999),
+            metavar="INT",
+            default=1,
+            help="Minimum number of reads per strand to call a variant.",
+        )
 
     def _parse_args(self) -> argparse.Namespace:
         args = super()._parse_args()
@@ -170,6 +177,7 @@ class JunoMapping(Pipeline):
         self.species: str = args.species
         self.minimum_depth_variant: int = args.minimum_depth_variant
         self.minimum_allele_frequency: float = args.minimum_allele_frequency
+        self.min_reads_per_strand: int = args.min_reads_per_strand
 
         return args
 
@@ -251,6 +259,7 @@ class JunoMapping(Pipeline):
             "species": str(self.species),
             "minimum_depth": int(self.minimum_depth_variant),
             "minimum_allele_frequency": float(self.minimum_allele_frequency),
+            "min_reads_per_strand": int(self.min_reads_per_strand),
         }
 
 

--- a/workflow/rules/variant_filtering.smk
+++ b/workflow/rules/variant_filtering.smk
@@ -11,6 +11,8 @@ rule FilterMutectCalls:
         "docker://broadinstitute/gatk:4.3.0.0"
     conda:
         "../envs/gatk_picard.yaml"
+    params:
+        min_reads_per_strand=config["min_reads_per_strand"],
     log:
         OUT + "/log/FilterMutectCalls/{sample}.log",
     threads: config["threads"]["filter_variants"]
@@ -22,6 +24,7 @@ gatk FilterMutectCalls -V {input.vcf} \
 -R {input.ref} \
 -O {output.vcf} \
 --stats {input.stats} \
+--min-reads-per-strand {params.min_reads_per_strand} \
 --microbial-mode 2>&1>{log}
         """
 

--- a/workflow/rules/variant_filtering.smk
+++ b/workflow/rules/variant_filtering.smk
@@ -1,3 +1,31 @@
+rule FilterMutectCalls:
+    input:
+        vcf=OUT + "/variants_raw/raw/{sample}.vcf",
+        stats=OUT + "/variants_raw/raw/{sample}.vcf.stats",
+        ref=OUT + "/reference/reference.fasta",
+    output:
+        vcf=OUT + "/variants_raw/FMC/{sample}.vcf",
+    message:
+        "Marking low confidence variants for {wildcards.sample}, based on FilterMutectCalls microbial mode"
+    container:
+        "docker://broadinstitute/gatk:4.3.0.0"
+    conda:
+        "../envs/gatk_picard.yaml"
+    log:
+        OUT + "/log/FilterMutectCalls/{sample}.log",
+    threads: config["threads"]["filter_variants"]
+    resources:
+        mem_gb=config["mem_gb"]["filter_variants"],
+    shell:
+        """
+gatk FilterMutectCalls -V {input.vcf} \
+-R {input.ref} \
+-O {output.vcf} \
+--stats {input.stats} \
+--microbial-mode 2>&1>{log}
+        """
+
+
 rule filter_af:
     input:
         vcf=OUT + "/variants_raw/FMC/{sample}.vcf",
@@ -26,34 +54,6 @@ bcftools filter \
 {input.vcf} \
 1>{output.vcf} \
 2>{log}
-        """
-
-
-rule FilterMutectCalls:
-    input:
-        vcf=OUT + "/variants_raw/raw/{sample}.vcf",
-        stats=OUT + "/variants_raw/raw/{sample}.vcf.stats",
-        ref=OUT + "/reference/reference.fasta",
-    output:
-        vcf=OUT + "/variants_raw/FMC/{sample}.vcf",
-    message:
-        "Marking low confidence variants for {wildcards.sample}, based on FilterMutectCalls microbial mode"
-    container:
-        "docker://broadinstitute/gatk:4.3.0.0"
-    conda:
-        "../envs/gatk_picard.yaml"
-    log:
-        OUT + "/log/FilterMutectCalls/{sample}.log",
-    threads: config["threads"]["filter_variants"]
-    resources:
-        mem_gb=config["mem_gb"]["filter_variants"],
-    shell:
-        """
-gatk FilterMutectCalls -V {input.vcf} \
--R {input.ref} \
--O {output.vcf} \
---stats {input.stats} \
---microbial-mode 2>&1>{log}
         """
 
 


### PR DESCRIPTION
Variants which do not have at least 1 FW and 1 RV read supporting it, will be marked as filtered because of `strict_strand`. This is a low priority filter, with priorities from high to low:
1. masked_region
2. min_depth_10
3. min_af_0.8
4. FilterMutectCalls filters (position, weak_evidence, base_qual and strict_strand)