### PR TITLE
fix: distinguish soft and hard AF filter

### DIFF
--- a/.github/workflows/juno_mapping_singularity.yaml
+++ b/.github/workflows/juno_mapping_singularity.yaml
@@ -36,7 +36,6 @@ jobs:
           generate-run-shell: false # see https://github.com/mamba-org/setup-micromamba/issues/130
           cache-downloads: true
           environment-file: envs/juno_mapping.yaml
-          create-args: --prefix /mnt/juno_mapping
       - name: Cache minikraken
         id: cache-minikraken
         uses: actions/cache@v3

--- a/.github/workflows/juno_mapping_singularity.yaml
+++ b/.github/workflows/juno_mapping_singularity.yaml
@@ -5,7 +5,7 @@ name: Singularity e2e test
 on: [pull_request]
 
 env:
-  KRAKEN_DEFAULT_DB: /home/runner/kraken-database
+  KRAKEN_DEFAULT_DB: /mnt/kraken-database
 
 jobs:
   singularity_end_to_end:
@@ -21,23 +21,21 @@ jobs:
       - name: check space 1
         shell: bash -l {0}
         run: |
+          echo "Checking space: ."
           df -h .
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 512
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-      - uses: actions/checkout@v2
+          echo "Checking space: /mnt"
+          df -h /mnt
+      - uses: actions/checkout@v4
       - uses: eWaterCycle/setup-singularity@v7
         with:
-          singularity-version: 3.8.7
+          singularity-version: 3.8.3
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
           generate-run-shell: false # see https://github.com/mamba-org/setup-micromamba/issues/130
           cache-downloads: true
           environment-file: envs/juno_mapping.yaml
+          environment-path: /mnt/juno_mapping
       - name: Cache minikraken
         id: cache-minikraken
         uses: actions/cache@v3
@@ -52,6 +50,7 @@ jobs:
           curl -k https://genome-idx.s3.amazonaws.com/kraken/k2_viral_20220908.tar.gz > k2_viral_20220908.tar.gz
           tar zxvf k2_viral_20220908.tar.gz
           ls -lh
+          rm k2_viral_20220908.tar.gz
       - name: Conda list
         shell: bash -l {0}
         run: conda list
@@ -66,7 +65,10 @@ jobs:
             sudo rm -rf /opt/ghc
             sudo rm -rf "/usr/local/share/boost"
           fi
+          echo "Checking space: ."
           df -h .
+          echo "Checking space: /mnt"
+          df -h /mnt
           which singularity
           singularity --version
       - name: Test juno_mapping pipeline using singularity.
@@ -79,6 +81,7 @@ jobs:
         if: always()
         shell: bash -l {0}
         run: | 
+          echo "Checking space: ."
           df -h .
-
-  
+          echo "Checking space: /mnt"
+          df -h /mnt

--- a/.github/workflows/juno_mapping_singularity.yaml
+++ b/.github/workflows/juno_mapping_singularity.yaml
@@ -27,8 +27,8 @@ jobs:
           echo "Checking space: /mnt"
           df -h /mnt
           echo "Checking dir sizes"
-          du -sh *
-          du -sh */*
+          du -sh /*
+          du -sh /*/*
       - uses: actions/checkout@v4
       - uses: eWaterCycle/setup-singularity@v7
         with:
@@ -74,8 +74,8 @@ jobs:
           echo "Checking space: /mnt"
           df -h /mnt
           echo "Checking dir sizes"
-          du -sh *
-          du -sh */*
+          du -sh /*
+          du -sh /*/*
           which singularity
           singularity --version
       - name: Test juno_mapping pipeline using singularity.
@@ -93,5 +93,5 @@ jobs:
           echo "Checking space: /mnt"
           df -h /mnt
           echo "Checking dir sizes"
-          du -sh *
-          du -sh */*
+          du -sh /*
+          du -sh /*/*

--- a/.github/workflows/juno_mapping_singularity.yaml
+++ b/.github/workflows/juno_mapping_singularity.yaml
@@ -26,9 +26,6 @@ jobs:
           df -h .
           echo "Checking space: /mnt"
           df -h /mnt
-          echo "Checking dir sizes"
-          du -sh /*
-          du -sh /*/*
       - uses: actions/checkout@v4
       - uses: eWaterCycle/setup-singularity@v7
         with:
@@ -39,7 +36,7 @@ jobs:
           generate-run-shell: false # see https://github.com/mamba-org/setup-micromamba/issues/130
           cache-downloads: true
           environment-file: envs/juno_mapping.yaml
-          environment-path: /mnt/juno_mapping
+          create-args: --prefix /mnt/juno_mapping
       - name: Cache minikraken
         id: cache-minikraken
         uses: actions/cache@v3
@@ -73,9 +70,6 @@ jobs:
           df -h .
           echo "Checking space: /mnt"
           df -h /mnt
-          echo "Checking dir sizes"
-          du -sh /*
-          du -sh /*/*
           which singularity
           singularity --version
       - name: Test juno_mapping pipeline using singularity.
@@ -92,6 +86,6 @@ jobs:
           df -h .
           echo "Checking space: /mnt"
           df -h /mnt
-          echo "Checking dir sizes"
-          du -sh /*
-          du -sh /*/*
+          du -sh /mnt/juno_mapping
+          du -sh /mnt/kraken-database
+          du -sh ${{ env.GITHUB_WORKSPACE }}

--- a/.github/workflows/juno_mapping_singularity.yaml
+++ b/.github/workflows/juno_mapping_singularity.yaml
@@ -26,6 +26,9 @@ jobs:
           df -h .
           echo "Checking space: /mnt"
           df -h /mnt
+          echo "Checking dir sizes"
+          du -sh *
+          du -sh */*
       - uses: actions/checkout@v4
       - uses: eWaterCycle/setup-singularity@v7
         with:
@@ -70,6 +73,9 @@ jobs:
           df -h .
           echo "Checking space: /mnt"
           df -h /mnt
+          echo "Checking dir sizes"
+          du -sh *
+          du -sh */*
           which singularity
           singularity --version
       - name: Test juno_mapping pipeline using singularity.
@@ -86,3 +92,6 @@ jobs:
           df -h .
           echo "Checking space: /mnt"
           df -h /mnt
+          echo "Checking dir sizes"
+          du -sh *
+          du -sh */*

--- a/.github/workflows/juno_mapping_singularity.yaml
+++ b/.github/workflows/juno_mapping_singularity.yaml
@@ -2,7 +2,7 @@
 
 name: Singularity e2e test
 
-on: [pull_request]
+on: workflow_dispatch
 
 env:
   KRAKEN_DEFAULT_DB: /mnt/kraken-database

--- a/.github/workflows/juno_mapping_singularity.yaml
+++ b/.github/workflows/juno_mapping_singularity.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: check space 1
         shell: bash -l {0}
         run: |
+          sudo chmod -R 777 /mnt
           echo "Checking space: ."
           df -h .
           echo "Checking space: /mnt"

--- a/.github/workflows/juno_mapping_singularity.yaml
+++ b/.github/workflows/juno_mapping_singularity.yaml
@@ -18,6 +18,16 @@ jobs:
     name: Singularity Juno_mapping pipeline ${{ matrix.config.os }}
 
     steps:
+      - name: check space 1
+        shell: bash -l {0}
+        run: |
+          df -h .
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
       - uses: actions/checkout@v2
       - uses: eWaterCycle/setup-singularity@v7
         with:
@@ -45,7 +55,7 @@ jobs:
       - name: Conda list
         shell: bash -l {0}
         run: conda list
-      - name: check space
+      - name: check space 2
         shell: bash -l {0}
         run: |
           which singularity
@@ -65,7 +75,7 @@ jobs:
       - name: Test the juno_mapping wrapper
         shell: bash -l {0}
         run: pytest -v tests/test_juno_mapping.py
-      - name: check space 2
+      - name: check space 3
         if: always()
         shell: bash -l {0}
         run: | 

--- a/.github/workflows/juno_mapping_singularity.yaml
+++ b/.github/workflows/juno_mapping_singularity.yaml
@@ -85,6 +85,8 @@ jobs:
           df -h .
           echo "Checking space: /mnt"
           df -h /mnt
-          du -sh /mnt/juno_mapping
           du -sh /mnt/kraken-database
-          du -sh ${{ env.GITHUB_WORKSPACE }}
+          echo "Checking space: $GITHUB_WORKSPACE"
+          du -sh $GITHUB_WORKSPACE
+          echo "Checking space: /home/runner"
+          du -sh /home/runner/*

--- a/juno_mapping.py
+++ b/juno_mapping.py
@@ -184,8 +184,12 @@ class JunoMapping(Pipeline):
         self.time_limit: int = args.time_limit
         self.species: str = args.species
         self.minimum_depth_variant: int = args.minimum_depth_variant
-        self.hard_filter_minimum_allele_frequency: float = args.hard_filter_minimum_allele_frequency
-        self.soft_filter_minimum_allele_frequency: float = args.soft_filter_minimum_allele_frequency
+        self.hard_filter_minimum_allele_frequency: float = (
+            args.hard_filter_minimum_allele_frequency
+        )
+        self.soft_filter_minimum_allele_frequency: float = (
+            args.soft_filter_minimum_allele_frequency
+        )
         self.min_reads_per_strand: int = args.min_reads_per_strand
 
         return args
@@ -267,8 +271,12 @@ class JunoMapping(Pipeline):
             "use_singularity": str(self.snakemake_args["use_singularity"]),
             "species": str(self.species),
             "minimum_depth": int(self.minimum_depth_variant),
-            "soft_filter_minimum_allele_frequency": float(self.soft_filter_minimum_allele_frequency),
-            "hard_filter_minimum_allele_frequency": float(self.hard_filter_minimum_allele_frequency),
+            "soft_filter_minimum_allele_frequency": float(
+                self.soft_filter_minimum_allele_frequency
+            ),
+            "hard_filter_minimum_allele_frequency": float(
+                self.hard_filter_minimum_allele_frequency
+            ),
             "min_reads_per_strand": int(self.min_reads_per_strand),
         }
 

--- a/juno_mapping.py
+++ b/juno_mapping.py
@@ -145,12 +145,20 @@ class JunoMapping(Pipeline):
             help="Minimum length for fastq reads to be kept after trimming.",
         )
         self.add_argument(
-            "-maf",
-            "--minimum-allele-frequency",
+            "-smaf",
+            "--soft-filter-minimum-allele-frequency",
             type=check_number_within_range(minimum=0, maximum=1),
             metavar="FLOAT",
             default=0.8,
-            help="Minimum allele frequency to filter variants on.",
+            help="Minimum allele frequency to soft filter variants on. Soft filtering is done by adding a filter tag to the VCF file.",
+        )
+        self.add_argument(
+            "-hmaf",
+            "--hard-filter-minimum-allele-frequency",
+            type=check_number_within_range(minimum=0, maximum=1),
+            metavar="FLOAT",
+            default=0.2,
+            help="Minimum allele frequency to hard filter variants on. Hard filtering is done by removing variants from the VCF file.",
         )
         self.add_argument(
             "--min-reads-per-strand",
@@ -176,7 +184,8 @@ class JunoMapping(Pipeline):
         self.time_limit: int = args.time_limit
         self.species: str = args.species
         self.minimum_depth_variant: int = args.minimum_depth_variant
-        self.minimum_allele_frequency: float = args.minimum_allele_frequency
+        self.hard_filter_minimum_allele_frequency: float = args.hard_filter_minimum_allele_frequency
+        self.soft_filter_minimum_allele_frequency: float = args.soft_filter_minimum_allele_frequency
         self.min_reads_per_strand: int = args.min_reads_per_strand
 
         return args
@@ -258,7 +267,8 @@ class JunoMapping(Pipeline):
             "use_singularity": str(self.snakemake_args["use_singularity"]),
             "species": str(self.species),
             "minimum_depth": int(self.minimum_depth_variant),
-            "minimum_allele_frequency": float(self.minimum_allele_frequency),
+            "soft_filter_minimum_allele_frequency": float(self.soft_filter_minimum_allele_frequency),
+            "hard_filter_minimum_allele_frequency": float(self.hard_filter_minimum_allele_frequency),
             "min_reads_per_strand": int(self.min_reads_per_strand),
         }
 

--- a/tests/test_juno_mapping.py
+++ b/tests/test_juno_mapping.py
@@ -122,7 +122,7 @@ class TestJunoMappingDryRun(unittest.TestCase):
         expected_user_param_values = {
             "species": "mycobacterium_tuberculosis",
             "reference": "reference.fasta",
-            "minimum_allele_frequency": 0.8,
+            "soft_filter_minimum_allele_frequency": 0.8,
             "minimum_depth": 10,
             "disable_mask": "False",
             "mask_bed": "files/RLC_Farhat.bed",

--- a/tests/test_juno_mapping.py
+++ b/tests/test_juno_mapping.py
@@ -147,7 +147,7 @@ class TestJunoMappingDryRun(unittest.TestCase):
                 "--reference",
                 "reference.fasta",
                 "--disable-mask",
-                "-maf",
+                "-smaf",
                 "0.5",
                 "-md",
                 "20",
@@ -159,7 +159,7 @@ class TestJunoMappingDryRun(unittest.TestCase):
         expected_user_param_values = {
             "species": "mycobacterium_tuberculosis",
             "reference": "reference.fasta",
-            "minimum_allele_frequency": 0.5,
+            "soft_filter_minimum_allele_frequency": 0.5,
             "minimum_depth": 20,
             "disable_mask": "True",
             "mask_bed": "None",

--- a/tests/test_pipeline_singularity.py
+++ b/tests/test_pipeline_singularity.py
@@ -43,7 +43,7 @@ class TestJunoMappingPipelineSingularity(unittest.TestCase):
         46679: {"REF": "C", "ALT": "G"},
     }
 
-    output_dir = Path("pipeline_test_output_singularity")
+    output_dir = Path("/mnt/pipeline_test_output_singularity")
     input_dir = "tests"
 
     @classmethod
@@ -81,7 +81,7 @@ class TestJunoMappingPipelineSingularity(unittest.TestCase):
                 "--db-dir",
                 str(kraken_db),
                 "--prefix",
-                "/home/runner/sing_containers",
+                "/mnt/sing_containers",
             ]
         )
         pipeline.run()

--- a/tests/test_pipeline_singularity.py
+++ b/tests/test_pipeline_singularity.py
@@ -61,7 +61,7 @@ class TestJunoMappingPipelineSingularity(unittest.TestCase):
             kraken_db = Path.home().joinpath("kraken-database")
             assert kraken_db.exists(), "Kraken database not found"
         else:
-            kraken_db = Path("/home/runner/kraken-database")
+            kraken_db = Path("/mnt/kraken-database")
 
         pipeline = JunoMapping(
             argv=[

--- a/workflow/rules/qc_variant_calling.smk
+++ b/workflow/rules/qc_variant_calling.smk
@@ -1,6 +1,6 @@
 rule get_filter_status:
     input:
-        vcf=OUT + "/variants_raw/FMC_af_depth_masked/{sample}.vcf",
+        vcf=OUT + "/variants/{sample}.vcf",
     output:
         tsv=OUT + "/qc_variant_calling/get_filter_status/{sample}.tsv",
     message:

--- a/workflow/rules/variant_filtering.smk
+++ b/workflow/rules/variant_filtering.smk
@@ -135,7 +135,7 @@ if config["disable_mask"] == "True":
             ref=OUT + "/reference/reference.fasta",
             mask=OUT + "/variants_raw/no_mask.bed",
         output:
-            vcf=OUT + "/variants_raw/FMC_afhard_afsoft_depth_masked/{sample}.vcf",
+            vcf=OUT + "/variants/{sample}.vcf",
         log:
             OUT + "/log/filter_depth/{sample}.log",
         threads: config["threads"]["filter_variants"]


### PR DESCRIPTION
Main output VCF (which is found by juno-lib) contains soft-filtered variants now, with a comment in the FILTER column. A hard-filtered VCF is also produced but not used for juno-variant-typing now