### PR TITLE
fix: added checkpoint for coverage check for delly and filtering dele…

### DIFF
--- a/config/pipeline_parameters.yaml
+++ b/config/pipeline_parameters.yaml
@@ -25,4 +25,4 @@ mem_gb:
     bbtools: 64
     delly: 16
     other: 8
-    calculate_coverage: 32
+    calculate_coverage: 8

--- a/config/pipeline_parameters.yaml
+++ b/config/pipeline_parameters.yaml
@@ -25,3 +25,4 @@ mem_gb:
     bbtools: 64
     delly: 16
     other: 8
+    calculate_coverage: 32

--- a/workflow/rules/variant_calling.smk
+++ b/workflow/rules/variant_calling.smk
@@ -31,12 +31,43 @@ gatk Mutect2 \
 --max-reads-per-alignment-start 75 2>&1>{log}
         """
 
+rule extract_mean_coverage:
+    input:
+        wgs_metrics=OUT + "/qc_mapping/CollectWgsMetrics/{sample}.txt",
+    output:
+        mean_coverage=OUT + "/coverage/{sample}_mean_coverage.txt",
+    # conda:
+    #     "../envs/pandas.yaml"
+    resources:
+        mem_gb=config["mem_gb"]["calculate_coverage"],
+    log:
+        OUT + "/log/extract_mean_coverage/{sample}.log",
+    script:
+        "../scripts/parse_wgs_metrics.py"
+
+checkpoint check_mean_coverage:
+    input:
+        mean_coverage=OUT + "/coverage/{sample}_mean_coverage.txt",
+    output:
+        flag=OUT + "/coverage/{sample}_coverage_flag.txt",
+    resources:
+        mem_gb=config["mem_gb"]["calculate_coverage"],
+    run:
+        with open(input.mean_coverage) as f:
+            mean_coverage = float(f.read().strip())
+        if mean_coverage < 1:
+            flag = "low"
+        else:
+            flag = "sufficient"
+        with open(output.flag, "w") as f:
+            f.write(flag)
 
 rule delly_call:
     input:
         bam=OUT + "/mapped_reads/duprem/{sample}.bam",
         bai=OUT + "/mapped_reads/duprem/{sample}.bam.bai",
         ref=OUT + "/reference/reference.fasta",
+        flag=lambda wildcards: checkpoints.check_mean_coverage.get(sample=wildcards.sample).output.flag,
     output:
         bcf=OUT + "/variants_raw/delly_raw/{sample}.bcf",
     container:
@@ -50,10 +81,37 @@ rule delly_call:
         mem_gb=config["mem_gb"]["delly"],
     shell:
         """
-delly call \
--t DEL \
--g {input.ref} \
-{input.bam} \
--o {output.bcf} \
-2>&1>{log}
+        if [ $(cat {input.flag}) = "low" ]; then
+            echo "large deletions not filtered for the sample" > {log}
+            echo "##fileformat=VCFv4.2" > {output.bcf}
+            echo "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" >> {output.bcf}
+        else
+            delly call -t DEL -g {input.ref} {input.bam} -o {output.bcf} 2>&1>{log}
+        fi
         """
+
+# rule delly_call:
+#     input:
+#         bam=OUT + "/mapped_reads/duprem/{sample}.bam",
+#         bai=OUT + "/mapped_reads/duprem/{sample}.bam.bai",
+#         ref=OUT + "/reference/reference.fasta",
+#     output:
+#         bcf=OUT + "/variants_raw/delly_raw/{sample}.bcf",
+#     container:
+#         "docker://quay.io/biocontainers/delly:1.2.6--hb7e2ac5_0"
+#     conda:
+#         "../envs/delly.yaml"
+#     log:
+#         OUT + "/log/variant_calling_delly/{sample}.log",
+#     threads: config["threads"]["delly"]
+#     resources:
+#         mem_gb=config["mem_gb"]["delly"],
+#     shell:
+#         """
+# delly call \
+# -t DEL \
+# -g {input.ref} \
+# {input.bam} \
+# -o {output.bcf} \
+# 2>&1>{log}
+#         """

--- a/workflow/scripts/parse_wgs_metrics.py
+++ b/workflow/scripts/parse_wgs_metrics.py
@@ -1,0 +1,39 @@
+import pandas as pd
+
+def parse_wgs_metrics(wgs_metrics_file, output_mean_coverage):
+    """
+    Parse the WgsMetrics file and return the mean coverage.
+    """
+    # Read the WgsMetrics file
+    df = pd.read_csv(wgs_metrics_file, sep='\t', comment='#', skiprows=6, nrows=1)
+
+    # Extract the mean coverage
+    mean_coverage = df['MEAN_COVERAGE'].values[0]
+
+    # Write the mean coverage to the output file
+    with open(output_mean_coverage, "w") as f:
+        f.write(str(mean_coverage))
+
+
+# Extract file paths from snakemake input and output
+wgs_metrics_file = str(snakemake.input[0])  # type: ignore[name-defined]
+output_mean_coverage = str(snakemake.output[0])  # type: ignore[name-defined]
+
+# Call the function with the extracted file paths
+parse_wgs_metrics(wgs_metrics_file, output_mean_coverage)
+
+# import pandas as pd
+# import sys
+
+# input_wgs_metrics = sys.argv[1]
+# output_mean_coverage = sys.argv[2]
+
+# # Read the WgsMetrics file
+# df = pd.read_csv(input_wgs_metrics, sep='\t', comment='#', skiprows=6, nrows=1)
+
+# # Extract the mean coverage
+# mean_coverage = df['MEAN_COVERAGE'].values[0]
+
+# # Write the mean coverage to the output file
+# with open(output_mean_coverage, "w") as f:
+#     f.write(str(mean_coverage))


### PR DESCRIPTION
Hi Boas, I added a checkpoint which checks the mean coverage from wgs metrics file and creates flags. The delly rule is then run according to if the flag states 'low' or 'sufficient'. Low is any mean coverage < 1 (this was a test threshold because I noticed the samples that were failing were below this but we can choose a better one based on more testing. I also use the checkpoint in variant_filtering.smk rule filter_large_deletions as this rule depends on the output of delly. If the coverage is flagged as low, i have for now just created empty files because the delly tool does not seem to have a (clear) option of dealing with the low cov samples.